### PR TITLE
fix(integration-test): Fix before test actions

### DIFF
--- a/app/dv/src/main/java/io/syndesis/dv/openshift/SyndesisConnectionMonitor.java
+++ b/app/dv/src/main/java/io/syndesis/dv/openshift/SyndesisConnectionMonitor.java
@@ -47,6 +47,7 @@ public class SyndesisConnectionMonitor {
     private ObjectMapper mapper = new ObjectMapper();
     private SyndesisConnectionSynchronizer connectionSynchronizer;
     private ScheduledThreadPoolExecutor executor;
+    private static volatile boolean UPDATE = true;
 
     static class Message {
         private String event;
@@ -224,12 +225,17 @@ public class SyndesisConnectionMonitor {
         this.executor.scheduleAtFixedRate(()->this.connect(), 5, 15, TimeUnit.SECONDS);
         this.executor.scheduleAtFixedRate(()->{
             try {
-                if (connected) {
+                if (connected && UPDATE) {
                     connectionSynchronizer.synchronizeConnections(true);
+                    UPDATE = false;
                 }
             } catch (KException e) {
                 LOGGER.error("failed to synchronize", e);
             }
-        }, 5, 5, TimeUnit.MINUTES);
+        }, 5, 15, TimeUnit.MINUTES);
+    }
+
+    public static void setUpdate(boolean update) {
+        UPDATE = update;
     }
 }

--- a/app/dv/src/main/java/io/syndesis/dv/server/V1Constants.java
+++ b/app/dv/src/main/java/io/syndesis/dv/server/V1Constants.java
@@ -135,7 +135,7 @@ public interface V1Constants extends StringConstants {
     /**
      * syndesis source summaries segment
      */
-    String SYNDESIS_SOURCE_STATUSES = "syndesisSourceStatuses"; //$NON-NLS-1$
+    String SOURCE_STATUSES = "sourceStatuses"; //$NON-NLS-1$
 
     /**
      * The view editor state of the user profile

--- a/app/dv/src/main/java/io/syndesis/dv/server/endpoint/MetadataService.java
+++ b/app/dv/src/main/java/io/syndesis/dv/server/endpoint/MetadataService.java
@@ -65,6 +65,7 @@ import io.syndesis.dv.metadata.internal.DefaultMetadataInstance;
 import io.syndesis.dv.metadata.query.QSResult;
 import io.syndesis.dv.model.DataVirtualization;
 import io.syndesis.dv.model.SourceSchema;
+import io.syndesis.dv.openshift.SyndesisConnectionMonitor;
 import io.syndesis.dv.openshift.TeiidOpenShiftClient;
 import io.syndesis.dv.server.DvService;
 import io.syndesis.dv.server.Messages;
@@ -204,6 +205,7 @@ public class MetadataService extends DvService implements ServiceVdbGenerator.Sc
     }
 
     protected TeiidVdb updatePreviewVdb(String dvName) throws Exception {
+        SyndesisConnectionMonitor.setUpdate(true);
         return repositoryManager.runInTransaction(true, ()->{
             DataVirtualization dv = repositoryManager.findDataVirtualization(dvName);
             if (dv == null) {
@@ -419,6 +421,7 @@ public class MetadataService extends DvService implements ServiceVdbGenerator.Sc
         @ApiResponse( code = 406, message = "Only JSON is returned by this operation" )
     } )
     public List<RestSchemaNode> getAllConnectionSchema() throws Exception {
+        SyndesisConnectionMonitor.setUpdate(true);
         return repositoryManager.runInTransaction(true, ()->{
             List<RestSchemaNode> rootNodes = new ArrayList<RestSchemaNode>();
 

--- a/app/dv/src/test/java/io/syndesis/dv/server/endpoint/IntegrationTest.java
+++ b/app/dv/src/test/java/io/syndesis/dv/server/endpoint/IntegrationTest.java
@@ -292,7 +292,7 @@ public class IntegrationTest {
         //test that unqualified does not work
         query("select col from t union select 1 as col", dvName, false);
 
-        ResponseEntity<List> sourceStatusResponse = restTemplate.getForEntity("/v1/metadata/syndesisSourceStatuses", List.class);
+        ResponseEntity<List> sourceStatusResponse = restTemplate.getForEntity("/v1/metadata/sourceStatuses", List.class);
         assertEquals(HttpStatus.OK, sourceStatusResponse.getStatusCode());
         Map status = (Map)sourceStatusResponse.getBody().get(0);
         assertEquals(0, ((List)status.get("errors")).size());
@@ -352,7 +352,7 @@ public class IntegrationTest {
             }
         }
 
-        sourceStatusResponse = restTemplate.getForEntity("/v1/metadata/syndesisSourceStatuses", List.class);
+        sourceStatusResponse = restTemplate.getForEntity("/v1/metadata/sourceStatuses", List.class);
         assertEquals(HttpStatus.OK, sourceStatusResponse.getStatusCode());
         status = (Map)sourceStatusResponse.getBody().get(0);
         assertEquals(1, ((List)status.get("errors")).size());

--- a/app/dv/src/test/java/io/syndesis/dv/server/endpoint/MetadataServiceTest.java
+++ b/app/dv/src/test/java/io/syndesis/dv/server/endpoint/MetadataServiceTest.java
@@ -108,7 +108,7 @@ public class MetadataServiceTest {
     public void testGetSchema() throws Exception {
         List<RestSchemaNode> nodes = null;
         try {
-            nodes = metadataService.getSchema("source2");
+            nodes = metadataService.getSourceSchema("source2");
             fail();
         } catch (ResponseStatusException e) {
             //no source yet
@@ -121,35 +121,41 @@ public class MetadataServiceTest {
                 "create foreign table tbl (col string) options (\"teiid_rel:fqn\" 'schema=s%20x/t%20bl=bar');"
                 + "create foreign table tbl1 (col string) options (\"teiid_rel:fqn\" 'schema=s%20x/t%20bl=bar1');");
 
-        nodes = metadataService.getSchema("source2");
-        assertEquals("[ {\n" +
-                "  \"children\" : [ {\n" +
-                "    \"children\" : [ ],\n" +
-                "    \"name\" : \"bar\",\n" +
-                "    \"teiidName\" : \"tbl\",\n" +
-                "    \"connectionName\" : \"source2\",\n" +
-                "    \"type\" : \"t bl\",\n" +
-                "    \"queryable\" : true\n" +
-                "  }, {\n" +
-                "    \"children\" : [ ],\n" +
-                "    \"name\" : \"bar1\",\n" +
-                "    \"teiidName\" : \"tbl1\",\n" +
-                "    \"connectionName\" : \"source2\",\n" +
-                "    \"type\" : \"t bl\",\n" +
-                "    \"queryable\" : true\n" +
-                "  } ],\n" +
-                "  \"name\" : \"s x\",\n" +
-                "  \"connectionName\" : \"source2\",\n" +
-                "  \"type\" : \"schema\",\n" +
-                "  \"queryable\" : false\n" +
-                "} ]", JsonMarshaller.marshall(nodes));
-    }
-
+        nodes = metadataService.getSourceSchema("source2");
+        assertEquals(
+            "[ {\n" +
+            "  \"children\" : [ {\n" +
+            "    \"children\" : [ {\n" +
+            "      \"children\" : [ ],\n" +
+            "      \"name\" : \"bar\",\n" +
+            "      \"teiidName\" : \"tbl\",\n" +
+            "      \"connectionName\" : \"source2\",\n" +
+            "      \"type\" : \"t bl\",\n" +
+            "      \"queryable\" : true\n" +
+            "    }, {\n" +
+            "      \"children\" : [ ],\n" +
+            "      \"name\" : \"bar1\",\n" +
+            "      \"teiidName\" : \"tbl1\",\n" +
+            "      \"connectionName\" : \"source2\",\n" +
+            "      \"type\" : \"t bl\",\n" +
+            "      \"queryable\" : true\n" +
+            "    } ],\n" +
+            "    \"name\" : \"s x\",\n" +
+            "    \"connectionName\" : \"source2\",\n" +
+            "    \"type\" : \"schema\",\n" +
+            "    \"queryable\" : false\n" +
+            "  } ],\n" +
+            "  \"name\" : \"source2\",\n" +
+            "  \"type\" : \"teiidSource\",\n" +
+            "  \"queryable\" : false\n" +
+            "} ]", JsonMarshaller.marshall(nodes));
+        }
+  
     @Test
     public void testGetSchemaSingleLevel() throws Exception {
         List<RestSchemaNode> nodes = null;
         try {
-            nodes = metadataService.getSchema("source3");
+            nodes = metadataService.getSourceSchema("source3");
             fail();
         } catch (ResponseStatusException e) {
             //no source yet
@@ -164,22 +170,28 @@ public class MetadataServiceTest {
                 "create foreign table tbl (col string) options (\"teiid_rel:fqn\" 'collection=bar');"
                 + "create foreign table tbl1 (col string) options (\"teiid_rel:fqn\" 'collection=bar1');");
 
-        nodes = metadataService.getSchema("source3");
-        assertEquals("[ {\n" +
-                "  \"children\" : [ ],\n" +
-                "  \"name\" : \"bar\",\n" +
-                "  \"teiidName\" : \"tbl\",\n" +
-                "  \"connectionName\" : \"source3\",\n" +
-                "  \"type\" : \"collection\",\n" +
-                "  \"queryable\" : true\n" +
-                "}, {\n" +
-                "  \"children\" : [ ],\n" +
-                "  \"name\" : \"bar1\",\n" +
-                "  \"teiidName\" : \"tbl1\",\n" +
-                "  \"connectionName\" : \"source3\",\n" +
-                "  \"type\" : \"collection\",\n" +
-                "  \"queryable\" : true\n" +
-                "} ]", JsonMarshaller.marshall(nodes));
+        nodes = metadataService.getSourceSchema("source3");
+        assertEquals(
+            "[ {\n" +
+            "  \"children\" : [ {\n" +
+            "    \"children\" : [ ],\n" +
+            "    \"name\" : \"bar\",\n" +
+            "    \"teiidName\" : \"tbl\",\n" +
+            "    \"connectionName\" : \"source3\",\n" +
+            "    \"type\" : \"collection\",\n" +
+            "    \"queryable\" : true\n" +
+            "  }, {\n" +
+            "    \"children\" : [ ],\n" +
+            "    \"name\" : \"bar1\",\n" +
+            "    \"teiidName\" : \"tbl1\",\n" +
+            "    \"connectionName\" : \"source3\",\n" +
+            "    \"type\" : \"collection\",\n" +
+            "    \"queryable\" : true\n" +
+            "  } ],\n" +
+            "  \"name\" : \"source3\",\n" +
+            "  \"type\" : \"teiidSource\",\n" +
+            "  \"queryable\" : false\n" +
+            "} ]", JsonMarshaller.marshall(nodes));
     }
 
     @Test

--- a/app/server/update-controller/src/test/java/io/syndesis/server/update/controller/usage/UsageUpdateHandlerTest.java
+++ b/app/server/update-controller/src/test/java/io/syndesis/server/update/controller/usage/UsageUpdateHandlerTest.java
@@ -67,6 +67,24 @@ public class UsageUpdateHandlerTest {
             .build())
         .build();
 
+    private final Integration integrationWithDependencyLibraryExtension = new Integration.Builder()
+        .id("integration-2")
+        .addDependency(new Dependency.Builder()
+            .id("extension-1")
+            .type(Type.EXTENSION_TAG)
+            .build())
+        .build();
+
+    private final Integration integrationWithFlowsDependencyLibraryExtension = new Integration.Builder()
+        .id("integration-3")
+        .addFlow(new Flow.Builder()
+            .addDependency(new Dependency.Builder()
+                .id("extension-1")
+                .type(Type.EXTENSION_TAG)
+                .build())
+            .build())
+        .build();
+
     static class TestIntegrationBuilder extends Integration.Builder {
         TestIntegrationBuilder withFlowConnections(final Connection... connections) {
             return (TestIntegrationBuilder) addFlow(new Flow.Builder().addConnections(connections).build());
@@ -146,6 +164,32 @@ public class UsageUpdateHandlerTest {
     @Test
     public void shouldCountUsedExtensions() {
         when(dataManager.fetchAll(Integration.class)).thenReturn(ListResult.of(integrationWithExtension));
+
+        handler.processInternal(NOT_USED);
+
+        verify(dataManager).fetchAll(Integration.class);
+        verify(dataManager).fetchAll(Connection.class);
+        verify(dataManager).fetchAll(Extension.class);
+        verify(dataManager).update(UsageUpdateHandler.withUpdatedUsage(extension, 1));
+        verifyNoMoreInteractions(dataManager);
+    }
+
+    @Test
+    public void shouldCountUsedIntegrationDependencyLibrariesExtensions() {
+        when(dataManager.fetchAll(Integration.class)).thenReturn(ListResult.of(integrationWithDependencyLibraryExtension));
+
+        handler.processInternal(NOT_USED);
+
+        verify(dataManager).fetchAll(Integration.class);
+        verify(dataManager).fetchAll(Connection.class);
+        verify(dataManager).fetchAll(Extension.class);
+        verify(dataManager).update(UsageUpdateHandler.withUpdatedUsage(extension, 1));
+        verifyNoMoreInteractions(dataManager);
+    }
+
+    @Test
+    public void shouldCountUsedFlowsDependencyLibrariesExtensions() {
+        when(dataManager.fetchAll(Integration.class)).thenReturn(ListResult.of(integrationWithFlowsDependencyLibraryExtension));
 
         handler.processInternal(NOT_USED);
 

--- a/app/test/integration-test/src/test/java/io/syndesis/test/itest/apiprovider/TodoApi_IT.java
+++ b/app/test/integration-test/src/test/java/io/syndesis/test/itest/apiprovider/TodoApi_IT.java
@@ -22,8 +22,6 @@ import java.util.Arrays;
 import com.consol.citrus.TestCaseRunner;
 import com.consol.citrus.annotations.CitrusResource;
 import com.consol.citrus.annotations.CitrusTest;
-import com.consol.citrus.container.BeforeTest;
-import com.consol.citrus.container.SequenceBeforeTest;
 import com.consol.citrus.http.client.HttpClient;
 import com.consol.citrus.http.client.HttpClientBuilder;
 import io.syndesis.test.SyndesisTestEnvironment;
@@ -98,6 +96,8 @@ public class TodoApi_IT extends SyndesisIntegrationTestSupport {
     @Test
     @CitrusTest
     public void testGetById(@CitrusResource TestCaseRunner runner) {
+        cleanupDatabase(runner);
+
         runner.given(sql(sampleDb)
                 .statement("insert into todo (id, task, completed) values (9999, 'Walk the dog', 0)"));
 
@@ -114,6 +114,8 @@ public class TodoApi_IT extends SyndesisIntegrationTestSupport {
     @Test
     @CitrusTest
     public void testGetAll(@CitrusResource TestCaseRunner runner) {
+        cleanupDatabase(runner);
+
         runner.given(sql(sampleDb)
                 .statements(Arrays.asList("insert into todo (task, completed) values ('Wash the dog', 0)",
                         "insert into todo (task, completed) values ('Feed the dog', 0)",
@@ -134,6 +136,8 @@ public class TodoApi_IT extends SyndesisIntegrationTestSupport {
     @Test
     @CitrusTest
     public void testGetOpen(@CitrusResource TestCaseRunner runner) {
+        cleanupDatabase(runner);
+
         runner.given(sql(sampleDb)
                 .statements(Arrays.asList("insert into todo (task, completed) values ('Wash the dog', 0)",
                         "insert into todo (task, completed) values ('Feed the dog', 0)",
@@ -156,6 +160,8 @@ public class TodoApi_IT extends SyndesisIntegrationTestSupport {
     @Test
     @CitrusTest
     public void testGetDone(@CitrusResource TestCaseRunner runner) {
+        cleanupDatabase(runner);
+
         runner.given(sql(sampleDb)
                 .statements(Arrays.asList("insert into todo (task, completed) values ('Wash the dog', 0)",
                         "insert into todo (task, completed) values ('Feed the dog', 0)",
@@ -182,16 +188,11 @@ public class TodoApi_IT extends SyndesisIntegrationTestSupport {
                     .requestUrl(String.format("http://localhost:%s", integrationContainer.getServerPort()))
                     .build();
         }
+    }
 
-        @Bean
-        public BeforeTest beforeTest(DataSource sampleDb) {
-            SequenceBeforeTest actions = new SequenceBeforeTest();
-            actions.addTestAction(
-                sql(sampleDb)
-                    .dataSource(sampleDb)
-                    .statement("delete from todo")
-            );
-            return actions;
-        }
+    private void cleanupDatabase(TestCaseRunner runner) {
+        runner.given(sql(sampleDb)
+            .dataSource(sampleDb)
+            .statement("delete from todo"));
     }
 }

--- a/app/test/integration-test/src/test/java/io/syndesis/test/itest/apiprovider/TodoListApi_IT.java
+++ b/app/test/integration-test/src/test/java/io/syndesis/test/itest/apiprovider/TodoListApi_IT.java
@@ -22,8 +22,6 @@ import java.util.Arrays;
 import com.consol.citrus.TestCaseRunner;
 import com.consol.citrus.annotations.CitrusResource;
 import com.consol.citrus.annotations.CitrusTest;
-import com.consol.citrus.container.BeforeTest;
-import com.consol.citrus.container.SequenceBeforeTest;
 import com.consol.citrus.http.client.HttpClient;
 import com.consol.citrus.http.client.HttpClientBuilder;
 import io.syndesis.test.SyndesisTestEnvironment;
@@ -77,6 +75,8 @@ public class TodoListApi_IT extends SyndesisIntegrationTestSupport {
     @Test
     @CitrusTest
     public void testGetOpenApiSpec(@CitrusResource TestCaseRunner runner) {
+        cleanupDatabase(runner);
+
         runner.given(waitFor().http()
                 .method(HttpMethod.GET.name())
                 .seconds(10L)
@@ -97,6 +97,8 @@ public class TodoListApi_IT extends SyndesisIntegrationTestSupport {
     @Test
     @CitrusTest
     public void testAddTodoList(@CitrusResource TestCaseRunner runner) {
+        cleanupDatabase(runner);
+
         runner.given(http().client(todoListApiClient)
                 .send()
                 .post("/todos")
@@ -117,6 +119,8 @@ public class TodoListApi_IT extends SyndesisIntegrationTestSupport {
     @Test
     @CitrusTest
     public void testGetTodoList(@CitrusResource TestCaseRunner runner) {
+        cleanupDatabase(runner);
+
         runner.given(sql(sampleDb)
                 .statements(Arrays.asList("insert into todo (task, completed) values ('Wash the dog', 0)",
                         "insert into todo (task, completed) values ('Feed the dog', 0)",
@@ -137,6 +141,8 @@ public class TodoListApi_IT extends SyndesisIntegrationTestSupport {
     @Test
     @CitrusTest
     public void testGetEmptyTodoList(@CitrusResource TestCaseRunner runner) {
+        cleanupDatabase(runner);
+
         runner.when(http().client(todoListApiClient)
                 .send()
                 .get("/todos"));
@@ -155,16 +161,11 @@ public class TodoListApi_IT extends SyndesisIntegrationTestSupport {
                     .requestUrl(String.format("http://localhost:%s", integrationContainer.getServerPort()))
                     .build();
         }
+    }
 
-        @Bean
-        public BeforeTest beforeTest(DataSource sampleDb) {
-            SequenceBeforeTest actions = new SequenceBeforeTest();
-            actions.addTestAction(
-                sql(sampleDb)
-                    .dataSource(sampleDb)
-                    .statement("delete from todo")
-            );
-            return actions;
-        }
+    private void cleanupDatabase(TestCaseRunner runner) {
+        runner.given(sql(sampleDb)
+            .dataSource(sampleDb)
+            .statement("delete from todo"));
     }
 }

--- a/app/test/integration-test/src/test/java/io/syndesis/test/itest/apiprovider/TodoOpenApiV3_IT.java
+++ b/app/test/integration-test/src/test/java/io/syndesis/test/itest/apiprovider/TodoOpenApiV3_IT.java
@@ -22,8 +22,6 @@ import java.util.Arrays;
 import com.consol.citrus.TestCaseRunner;
 import com.consol.citrus.annotations.CitrusResource;
 import com.consol.citrus.annotations.CitrusTest;
-import com.consol.citrus.container.BeforeTest;
-import com.consol.citrus.container.SequenceBeforeTest;
 import com.consol.citrus.http.client.HttpClient;
 import com.consol.citrus.http.client.HttpClientBuilder;
 import io.syndesis.test.SyndesisTestEnvironment;
@@ -89,6 +87,8 @@ public class TodoOpenApiV3_IT extends SyndesisIntegrationTestSupport {
     @Test
     @CitrusTest
     public void testGetOpenApiSpec(@CitrusResource TestCaseRunner runner) {
+        cleanupDatabase(runner);
+
         runner.when(http().client(todoApiClient)
                     .send()
                     .get("/openapi.json"));
@@ -103,6 +103,8 @@ public class TodoOpenApiV3_IT extends SyndesisIntegrationTestSupport {
     @Test
     @CitrusTest
     public void testGetTask(@CitrusResource TestCaseRunner runner) {
+        cleanupDatabase(runner);
+
         runner.variable("id", "citrus:randomNumber(4)");
 
         runner.given(sql(sampleDb)
@@ -121,6 +123,8 @@ public class TodoOpenApiV3_IT extends SyndesisIntegrationTestSupport {
     @Test
     @CitrusTest
     public void testTaskNotFound(@CitrusResource TestCaseRunner runner) {
+        cleanupDatabase(runner);
+
         runner.variable("id", "citrus:randomNumber(4)");
 
         runner.when(http().client(todoApiClient)
@@ -135,6 +139,8 @@ public class TodoOpenApiV3_IT extends SyndesisIntegrationTestSupport {
     @Test
     @CitrusTest
     public void testUpdateTask(@CitrusResource TestCaseRunner runner) {
+        cleanupDatabase(runner);
+
         runner.variable("id", "citrus:randomNumber(4)");
 
         runner.given(sql(sampleDb)
@@ -159,6 +165,8 @@ public class TodoOpenApiV3_IT extends SyndesisIntegrationTestSupport {
     @Test
     @CitrusTest
     public void testDeleteTask(@CitrusResource TestCaseRunner runner) {
+        cleanupDatabase(runner);
+
         runner.variable("id", "citrus:randomNumber(4)");
 
         runner.given(sql(sampleDb)
@@ -180,6 +188,8 @@ public class TodoOpenApiV3_IT extends SyndesisIntegrationTestSupport {
     @Test
     @CitrusTest
     public void testListTasks(@CitrusResource TestCaseRunner runner) {
+        cleanupDatabase(runner);
+
         runner.given(sql(sampleDb)
                 .statements(Arrays.asList("insert into todo (task, completed) values ('Wash the dog', 0)",
                         "insert into todo (task, completed) values ('Feed the dog', 0)",
@@ -207,16 +217,11 @@ public class TodoOpenApiV3_IT extends SyndesisIntegrationTestSupport {
                     .requestUrl(String.format("http://localhost:%s", integrationContainer.getServerPort()))
                     .build();
         }
+    }
 
-        @Bean
-        public BeforeTest beforeTest(DataSource sampleDb) {
-            SequenceBeforeTest actions = new SequenceBeforeTest();
-            actions.addTestAction(
-                sql(sampleDb)
-                    .dataSource(sampleDb)
-                    .statement("delete from todo")
-            );
-            return actions;
-        }
+    private void cleanupDatabase(TestCaseRunner runner) {
+        runner.given(sql(sampleDb)
+            .dataSource(sampleDb)
+            .statement("delete from todo"));
     }
 }

--- a/app/test/integration-test/src/test/java/io/syndesis/test/itest/conditional/ConditionalFlows_IT.java
+++ b/app/test/integration-test/src/test/java/io/syndesis/test/itest/conditional/ConditionalFlows_IT.java
@@ -21,8 +21,6 @@ import javax.sql.DataSource;
 import com.consol.citrus.TestCaseRunner;
 import com.consol.citrus.annotations.CitrusResource;
 import com.consol.citrus.annotations.CitrusTest;
-import com.consol.citrus.container.BeforeTest;
-import com.consol.citrus.container.SequenceBeforeTest;
 import com.consol.citrus.http.client.HttpClient;
 import com.consol.citrus.http.client.HttpClientBuilder;
 import io.syndesis.test.SyndesisTestEnvironment;
@@ -72,6 +70,8 @@ public class ConditionalFlows_IT extends SyndesisIntegrationTestSupport {
     @Test
     @CitrusTest
     public void testWebHookToDb(@CitrusResource TestCaseRunner runner) {
+        cleanupDatabase(runner);
+
         runner.when(http().client(webHookClient)
                 .send()
                 .post()
@@ -87,6 +87,8 @@ public class ConditionalFlows_IT extends SyndesisIntegrationTestSupport {
     @Test
     @CitrusTest
     public void testWebHookToDbBasicFilter(@CitrusResource TestCaseRunner runner) {
+        cleanupDatabase(runner);
+
         runner.when(http().client(webHookClient)
                 .send()
                 .post()
@@ -102,6 +104,8 @@ public class ConditionalFlows_IT extends SyndesisIntegrationTestSupport {
     @Test
     @CitrusTest
     public void testWebHookToDbAdvancedFilter(@CitrusResource TestCaseRunner runner) {
+        cleanupDatabase(runner);
+
         runner.when(http().client(webHookClient)
                 .send()
                 .post()
@@ -125,7 +129,6 @@ public class ConditionalFlows_IT extends SyndesisIntegrationTestSupport {
     }
 
     @Configuration
-    @SuppressWarnings("SpringJavaInjectionPointsAutowiringInspection")
     public static class EndpointConfig {
         @Bean
         public HttpClient webHookClient() {
@@ -133,16 +136,11 @@ public class ConditionalFlows_IT extends SyndesisIntegrationTestSupport {
                     .requestUrl(String.format("http://localhost:%s/webhook/test-webhook", integrationContainer.getServerPort()))
                     .build();
         }
+    }
 
-        @Bean
-        public BeforeTest beforeTest(DataSource sampleDb) {
-            SequenceBeforeTest actions = new SequenceBeforeTest();
-            actions.addTestAction(
-                sql(sampleDb)
-                    .dataSource(sampleDb)
-                    .statement("delete from todo")
-            );
-            return actions;
-        }
+    private void cleanupDatabase(TestCaseRunner runner) {
+        runner.given(sql(sampleDb)
+            .dataSource(sampleDb)
+            .statement("delete from todo"));
     }
 }

--- a/app/test/integration-test/src/test/java/io/syndesis/test/itest/ftp/FtpSplitToDB_IT.java
+++ b/app/test/integration-test/src/test/java/io/syndesis/test/itest/ftp/FtpSplitToDB_IT.java
@@ -68,6 +68,8 @@ public class FtpSplitToDB_IT extends FtpTestSupport {
     @Test
     @CitrusTest
     public void testFtpSplitToDB(@CitrusResource TestCaseRunner runner) {
+        cleanupDatabase(runner);
+
         runner.given(receive()
                 .endpoint(ftpTestServer)
                 .timeout(Duration.ofSeconds(SyndesisTestEnvironment.getDefaultTimeout()).toMillis())

--- a/app/test/integration-test/src/test/java/io/syndesis/test/itest/ftp/FtpTestSupport.java
+++ b/app/test/integration-test/src/test/java/io/syndesis/test/itest/ftp/FtpTestSupport.java
@@ -23,8 +23,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.stream.Stream;
 
-import com.consol.citrus.container.BeforeTest;
-import com.consol.citrus.container.SequenceBeforeTest;
+import com.consol.citrus.TestCaseRunner;
 import com.consol.citrus.exceptions.CitrusRuntimeException;
 import com.consol.citrus.ftp.client.FtpEndpointConfiguration;
 import com.consol.citrus.ftp.server.FtpServer;
@@ -99,17 +98,6 @@ public abstract class FtpTestSupport extends SyndesisIntegrationTestSupport {
 
             return ftpServer;
         }
-
-        @Bean
-        public BeforeTest beforeTest(DataSource sampleDb) {
-            SequenceBeforeTest actions = new SequenceBeforeTest();
-            actions.addTestAction(
-                sql(sampleDb)
-                    .dataSource(sampleDb)
-                    .statement("delete from todo")
-            );
-            return actions;
-        }
     }
 
     @BeforeClass
@@ -138,5 +126,11 @@ public abstract class FtpTestSupport extends SyndesisIntegrationTestSupport {
 
     public static Path getFtpUserHome() {
         return Paths.get("target/ftp/user/syndesis");
+    }
+
+    protected void cleanupDatabase(TestCaseRunner runner) {
+        runner.given(sql(sampleDb)
+            .dataSource(sampleDb)
+            .statement("delete from todo"));
     }
 }

--- a/app/test/integration-test/src/test/java/io/syndesis/test/itest/ftp/FtpToDB_IT.java
+++ b/app/test/integration-test/src/test/java/io/syndesis/test/itest/ftp/FtpToDB_IT.java
@@ -68,6 +68,8 @@ public class FtpToDB_IT extends FtpTestSupport {
     @Test
     @CitrusTest
     public void testFtpToDB(@CitrusResource TestCaseRunner runner) {
+        cleanupDatabase(runner);
+
         runner.given(receive()
                 .endpoint(ftpTestServer)
                 .timeout(Duration.ofSeconds(SyndesisTestEnvironment.getDefaultTimeout()).toMillis())

--- a/app/test/integration-test/src/test/java/io/syndesis/test/itest/ftp/WebHookToFtp_IT.java
+++ b/app/test/integration-test/src/test/java/io/syndesis/test/itest/ftp/WebHookToFtp_IT.java
@@ -81,6 +81,8 @@ public class WebHookToFtp_IT extends FtpTestSupport {
     @Test
     @CitrusTest
     public void testWebHookToFtp(@CitrusResource TestCaseRunner runner) {
+        cleanupDatabase(runner);
+
         runner.variable("first_name", "Joanne");
         runner.variable("company", "Red Hat");
         runner.variable("email", "joanne@syndesis.org");

--- a/app/test/integration-test/src/test/java/io/syndesis/test/itest/mail/SendMail_IT.java
+++ b/app/test/integration-test/src/test/java/io/syndesis/test/itest/mail/SendMail_IT.java
@@ -23,8 +23,6 @@ import java.time.Duration;
 import com.consol.citrus.TestCaseRunner;
 import com.consol.citrus.annotations.CitrusResource;
 import com.consol.citrus.annotations.CitrusTest;
-import com.consol.citrus.container.BeforeTest;
-import com.consol.citrus.container.SequenceBeforeTest;
 import com.consol.citrus.http.client.HttpClient;
 import com.consol.citrus.http.client.HttpClientBuilder;
 import com.consol.citrus.mail.message.CitrusMailMessageHeaders;
@@ -92,6 +90,8 @@ public class SendMail_IT extends SyndesisIntegrationTestSupport {
     @Test
     @CitrusTest
     public void testSendMail(@CitrusResource TestCaseRunner runner) throws IOException {
+        cleanupDatabase(runner);
+
         runner.variable("first_name", "John");
         runner.variable("company", "Red Hat");
         runner.variable("email", "john@syndesis.org");
@@ -125,6 +125,8 @@ public class SendMail_IT extends SyndesisIntegrationTestSupport {
     @Test
     @CitrusTest
     public void testSendMailError(@CitrusResource TestCaseRunner runner) {
+        cleanupDatabase(runner);
+
         runner.variable("first_name", "Joanne");
         runner.variable("company", "Red Hat");
         runner.variable("email", "joanne@syndesis.org");
@@ -178,15 +180,11 @@ public class SendMail_IT extends SyndesisIntegrationTestSupport {
                     .port(MAIL_SERVER_PORT)
                     .build();
         }
+    }
 
-        @Bean
-        public BeforeTest beforeTest(DataSource sampleDb) {
-            SequenceBeforeTest actions = new SequenceBeforeTest();
-            actions.addTestAction(
-                sql(sampleDb)
-                    .statement("delete from todo where task like 'New hire for%'")
-            );
-            return actions;
-        }
+    private void cleanupDatabase(TestCaseRunner runner) {
+        runner.given(sql(sampleDb)
+            .dataSource(sampleDb)
+            .statement("delete from todo"));
     }
 }

--- a/app/test/integration-test/src/test/java/io/syndesis/test/itest/quickstart/Webhook2DB_IT.java
+++ b/app/test/integration-test/src/test/java/io/syndesis/test/itest/quickstart/Webhook2DB_IT.java
@@ -21,8 +21,6 @@ import javax.sql.DataSource;
 import com.consol.citrus.TestCaseRunner;
 import com.consol.citrus.annotations.CitrusResource;
 import com.consol.citrus.annotations.CitrusTest;
-import com.consol.citrus.container.BeforeTest;
-import com.consol.citrus.container.SequenceBeforeTest;
 import com.consol.citrus.http.client.HttpClient;
 import com.consol.citrus.http.client.HttpClientBuilder;
 import io.syndesis.test.SyndesisTestEnvironment;
@@ -67,6 +65,8 @@ public class Webhook2DB_IT extends SyndesisIntegrationTestSupport {
     @Test
     @CitrusTest
     public void testWebhook2Db(@CitrusResource TestCaseRunner runner) {
+        cleanupDatabase(runner);
+
         runner.given(http().client(webHookClient)
                 .send()
                 .post()
@@ -82,7 +82,6 @@ public class Webhook2DB_IT extends SyndesisIntegrationTestSupport {
     }
 
     @Configuration
-    @SuppressWarnings("SpringJavaInjectionPointsAutowiringInspection")
     public static class EndpointConfig {
         @Bean
         public HttpClient webHookClient() {
@@ -90,16 +89,11 @@ public class Webhook2DB_IT extends SyndesisIntegrationTestSupport {
                     .requestUrl(String.format("http://localhost:%s/webhook/quickstart", integrationContainer.getServerPort()))
                     .build();
         }
+    }
 
-        @Bean
-        public BeforeTest beforeTest(DataSource sampleDb) {
-            SequenceBeforeTest actions = new SequenceBeforeTest();
-            actions.addTestAction(
-                sql(sampleDb)
-                    .dataSource(sampleDb)
-                    .statement("delete from todo")
-            );
-            return actions;
-        }
+    private void cleanupDatabase(TestCaseRunner runner) {
+        runner.given(sql(sampleDb)
+            .dataSource(sampleDb)
+            .statement("delete from todo"));
     }
 }

--- a/app/test/integration-test/src/test/java/io/syndesis/test/itest/sheets/DBSplitToSheets_IT.java
+++ b/app/test/integration-test/src/test/java/io/syndesis/test/itest/sheets/DBSplitToSheets_IT.java
@@ -65,6 +65,8 @@ public class DBSplitToSheets_IT extends GoogleSheetsTestSupport {
     @Test
     @CitrusTest
     public void testDBSplitToSheets(@CitrusResource TestCaseRunner runner) {
+        cleanupDatabase(runner, sampleDb);
+
         runner.given(sql(sampleDb)
                 .statements(Arrays.asList("insert into contact (first_name, last_name, company, lead_source) values ('Joe','Jackson','Red Hat','google-sheets')",
                                           "insert into contact (first_name, last_name, company, lead_source) values ('Joanne','Jackson','Red Hat','google-sheets')")));

--- a/app/test/integration-test/src/test/java/io/syndesis/test/itest/sheets/DBToSheets_IT.java
+++ b/app/test/integration-test/src/test/java/io/syndesis/test/itest/sheets/DBToSheets_IT.java
@@ -65,6 +65,8 @@ public class DBToSheets_IT extends GoogleSheetsTestSupport {
     @Test
     @CitrusTest
     public void testDBToSheets(@CitrusResource TestCaseRunner runner) {
+        cleanupDatabase(runner, sampleDb);
+
         runner.given(sql(sampleDb)
                 .statements(Arrays.asList("insert into contact (first_name, last_name, company, lead_source) values ('Joe','Jackson','Red Hat','google-sheets')",
                                           "insert into contact (first_name, last_name, company, lead_source) values ('Joanne','Jackson','Red Hat','google-sheets')")));

--- a/app/test/integration-test/src/test/java/io/syndesis/test/itest/sheets/GoogleSheetsTestSupport.java
+++ b/app/test/integration-test/src/test/java/io/syndesis/test/itest/sheets/GoogleSheetsTestSupport.java
@@ -22,8 +22,7 @@ import java.time.Duration;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
-import com.consol.citrus.container.BeforeTest;
-import com.consol.citrus.container.SequenceBeforeTest;
+import com.consol.citrus.TestCaseRunner;
 import com.consol.citrus.http.server.HttpServer;
 import com.consol.citrus.http.server.HttpServerBuilder;
 import com.consol.citrus.http.servlet.RequestCachingServletFilter;
@@ -65,16 +64,11 @@ public class GoogleSheetsTestSupport extends SyndesisIntegrationTestSupport {
                     .filters(filterMap)
                     .build();
         }
+    }
 
-        @Bean
-        public BeforeTest beforeTest(DataSource sampleDb) {
-            SequenceBeforeTest actions = new SequenceBeforeTest();
-            actions.addTestAction(
-                sql(sampleDb)
-                    .dataSource(sampleDb)
-                    .statement("delete from todo")
-            );
-            return actions;
-        }
+    protected void cleanupDatabase(TestCaseRunner runner, DataSource sampleDb) {
+        runner.given(sql(sampleDb)
+            .dataSource(sampleDb)
+            .statement("delete from todo"));
     }
 }

--- a/app/test/integration-test/src/test/java/io/syndesis/test/itest/sheets/MultiSqlToSheets_IT.java
+++ b/app/test/integration-test/src/test/java/io/syndesis/test/itest/sheets/MultiSqlToSheets_IT.java
@@ -66,6 +66,8 @@ public class MultiSqlToSheets_IT extends GoogleSheetsTestSupport {
     @Test
     @CitrusTest
     public void testMultiSqlMapper(@CitrusResource TestCaseRunner runner) {
+        cleanupDatabase(runner, sampleDb);
+
         runner.given(sql(sampleDb)
                 .statements(Arrays.asList("insert into contact (first_name, last_name, company, lead_source) values ('Joe','Jackson','Red Hat','google-sheets')",
                                           "insert into contact (first_name, last_name, company, lead_source) values ('Joanne','Jackson','Red Hat','google-sheets')")));

--- a/app/test/integration-test/src/test/java/io/syndesis/test/itest/sql/DBToHttp_IT.java
+++ b/app/test/integration-test/src/test/java/io/syndesis/test/itest/sql/DBToHttp_IT.java
@@ -23,8 +23,6 @@ import java.util.Arrays;
 import com.consol.citrus.TestCaseRunner;
 import com.consol.citrus.annotations.CitrusResource;
 import com.consol.citrus.annotations.CitrusTest;
-import com.consol.citrus.container.BeforeTest;
-import com.consol.citrus.container.SequenceBeforeTest;
 import com.consol.citrus.http.server.HttpServer;
 import com.consol.citrus.http.server.HttpServerBuilder;
 import io.syndesis.test.SyndesisTestEnvironment;
@@ -79,6 +77,8 @@ public class DBToHttp_IT extends SyndesisIntegrationTestSupport {
     @Test
     @CitrusTest
     public void testDBToHttp(@CitrusResource TestCaseRunner runner) {
+        cleanupDatabase(runner);
+
         runner.given(sql(sampleDb)
                 .statements(Arrays.asList("insert into contact (first_name, last_name, company) values ('Joe','Jackson','Red Hat')",
                                           "insert into contact (first_name, last_name, company) values ('Joanne','Jackson','Red Hat')")));
@@ -113,18 +113,11 @@ public class DBToHttp_IT extends SyndesisIntegrationTestSupport {
                     .timeout(Duration.ofSeconds(SyndesisTestEnvironment.getDefaultTimeout()).toMillis())
                     .build();
         }
-
-        @Bean
-        public BeforeTest beforeTest(DataSource sampleDb) {
-            SequenceBeforeTest actions = new SequenceBeforeTest();
-            actions.addTestAction(
-                sql(sampleDb)
-                    .dataSource(sampleDb)
-                    .statement("delete from todo")
-            );
-            return actions;
-        }
     }
 
-
+    private void cleanupDatabase(TestCaseRunner runner) {
+        runner.given(sql(sampleDb)
+            .dataSource(sampleDb)
+            .statement("delete from todo"));
+    }
 }

--- a/app/test/integration-test/src/test/java/io/syndesis/test/itest/webhook/WebHookSplitToDB_IT.java
+++ b/app/test/integration-test/src/test/java/io/syndesis/test/itest/webhook/WebHookSplitToDB_IT.java
@@ -23,8 +23,6 @@ import java.util.stream.Stream;
 import com.consol.citrus.TestCaseRunner;
 import com.consol.citrus.annotations.CitrusResource;
 import com.consol.citrus.annotations.CitrusTest;
-import com.consol.citrus.container.BeforeTest;
-import com.consol.citrus.container.SequenceBeforeTest;
 import com.consol.citrus.http.client.HttpClient;
 import com.consol.citrus.http.client.HttpClientBuilder;
 import io.syndesis.test.SyndesisTestEnvironment;
@@ -73,6 +71,8 @@ public class WebHookSplitToDB_IT extends SyndesisIntegrationTestSupport {
     @Test
     @CitrusTest
     public void testWebHookToDb(@CitrusResource TestCaseRunner runner) {
+        cleanupDatabase(runner);
+
         runner.when(http().client(webHookClient)
                 .send()
                 .post()
@@ -88,6 +88,8 @@ public class WebHookSplitToDB_IT extends SyndesisIntegrationTestSupport {
     @Test
     @CitrusTest
     public void testWebHookToDbBasicFilter(@CitrusResource TestCaseRunner runner) {
+        cleanupDatabase(runner);
+
         runner.when(http().client(webHookClient)
                 .send()
                 .post()
@@ -103,6 +105,8 @@ public class WebHookSplitToDB_IT extends SyndesisIntegrationTestSupport {
     @Test
     @CitrusTest
     public void testWebHookToDbAdvancedFilter(@CitrusResource TestCaseRunner runner) {
+        cleanupDatabase(runner);
+
         runner.when(http().client(webHookClient)
                 .send()
                 .post()
@@ -139,16 +143,11 @@ public class WebHookSplitToDB_IT extends SyndesisIntegrationTestSupport {
                     .requestUrl(String.format("http://localhost:%s/webhook/test-webhook", integrationContainer.getServerPort()))
                     .build();
         }
+    }
 
-        @Bean
-        public BeforeTest beforeTest(DataSource sampleDb) {
-            SequenceBeforeTest actions = new SequenceBeforeTest();
-            actions.addTestAction(
-                sql(sampleDb)
-                    .dataSource(sampleDb)
-                    .statement("delete from todo")
-            );
-            return actions;
-        }
+    private void cleanupDatabase(TestCaseRunner runner) {
+        runner.given(sql(sampleDb)
+            .dataSource(sampleDb)
+            .statement("delete from todo"));
     }
 }

--- a/app/test/integration-test/src/test/java/io/syndesis/test/itest/webhook/WebHookToDB_IT.java
+++ b/app/test/integration-test/src/test/java/io/syndesis/test/itest/webhook/WebHookToDB_IT.java
@@ -21,8 +21,6 @@ import javax.sql.DataSource;
 import com.consol.citrus.TestCaseRunner;
 import com.consol.citrus.annotations.CitrusResource;
 import com.consol.citrus.annotations.CitrusTest;
-import com.consol.citrus.container.BeforeTest;
-import com.consol.citrus.container.SequenceBeforeTest;
 import com.consol.citrus.http.client.HttpClient;
 import com.consol.citrus.http.client.HttpClientBuilder;
 import io.syndesis.test.SyndesisTestEnvironment;
@@ -84,6 +82,8 @@ public class WebHookToDB_IT extends SyndesisIntegrationTestSupport {
     @Test
     @CitrusTest
     public void testWebHookToDb(@CitrusResource TestCaseRunner runner) {
+        cleanupDatabase(runner);
+
         runner.when(http().client(webHookClient)
                 .send()
                 .post()
@@ -99,6 +99,8 @@ public class WebHookToDB_IT extends SyndesisIntegrationTestSupport {
     @Test
     @CitrusTest
     public void testWebHookToDbBasicFilter(@CitrusResource TestCaseRunner runner) {
+        cleanupDatabase(runner);
+
         runner.when(http().client(webHookClient)
                 .send()
                 .post()
@@ -114,6 +116,8 @@ public class WebHookToDB_IT extends SyndesisIntegrationTestSupport {
     @Test
     @CitrusTest
     public void testWebHookToDbAdvancedFilter(@CitrusResource TestCaseRunner runner) {
+        cleanupDatabase(runner);
+
         runner.when(http().client(webHookClient)
                 .send()
                 .post()
@@ -144,16 +148,11 @@ public class WebHookToDB_IT extends SyndesisIntegrationTestSupport {
                     .requestUrl(String.format("http://localhost:%s/webhook/test-webhook", integrationContainer.getServerPort()))
                     .build();
         }
+    }
 
-        @Bean
-        public BeforeTest beforeTest(DataSource sampleDb) {
-            SequenceBeforeTest actions = new SequenceBeforeTest();
-            actions.addTestAction(
-                sql(sampleDb)
-                    .dataSource(sampleDb)
-                    .statement("delete from todo")
-            );
-            return actions;
-        }
+    private void cleanupDatabase(TestCaseRunner runner) {
+        runner.given(sql(sampleDb)
+            .dataSource(sampleDb)
+            .statement("delete from todo"));
     }
 }

--- a/app/ui-react/packages/api/src/useVirtualizationConnectionSchema.tsx
+++ b/app/ui-react/packages/api/src/useVirtualizationConnectionSchema.tsx
@@ -3,8 +3,8 @@ import { useApiResource } from './useApiResource';
 
 export const useVirtualizationConnectionSchema = (teiidSourceName?: string) => {
   const url = teiidSourceName
-    ? `metadata/${teiidSourceName}/schema`
-    : `metadata/connectionSchema`;
+    ? `metadata/sourceSchema/${teiidSourceName}`
+    : `metadata/sourceSchema`;
 
   return useApiResource<SchemaNode[]>({
     defaultValue: [],

--- a/app/ui-react/packages/api/src/useVirtualizationConnectionStatuses.tsx
+++ b/app/ui-react/packages/api/src/useVirtualizationConnectionStatuses.tsx
@@ -5,7 +5,7 @@ import { usePolling } from './usePolling';
 export const useVirtualizationConnectionStatuses = (disableUpdates: boolean = false) => {
   const { read, ...rest } = useApiResource<VirtualizationSourceStatus[]>({
     defaultValue: [],
-    url: 'metadata/syndesisSourceStatuses',
+    url: 'metadata/sourceStatuses',
     useDvApiUrl: true,
   });
 

--- a/app/ui-react/syndesis/src/modules/data/shared/ViewInfosContent.tsx
+++ b/app/ui-react/syndesis/src/modules/data/shared/ViewInfosContent.tsx
@@ -157,7 +157,7 @@ export const ViewInfosContent: React.FunctionComponent<
     hasData,
     error,
     read,
-  } = useVirtualizationConnectionSchema();
+  } = useVirtualizationConnectionSchema(props.connectionTeiidName);
 
   React.useEffect(()=>{
     if (hasData) {

--- a/app/ui-react/syndesis/src/modules/data/shared/VirtualizationUtils.ts
+++ b/app/ui-react/syndesis/src/modules/data/shared/VirtualizationUtils.ts
@@ -174,7 +174,7 @@ export function generateSchemaNodeInfos(
       schemaNodeInfos.push(view);
     }
     // Update path for next level
-    if (schemaNode.type !== 'root') {
+    if (schemaNode.type !== 'teiidSource') {
       sourcePath.push(schemaNode.name);
     }
     // Process this nodes children


### PR DESCRIPTION
Add workaround for broken before test mechanism in Citrus 3.0.0-M1. Ensure to properly cleanup test database before tests.